### PR TITLE
Update CI scripts after changing branches

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,11 +1,12 @@
 on:
   push:
     branches:
+    - main
     - master
     - release/*
   pull_request:
     branches:
-    - master
+    - main
 jobs:
   validation:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The sources were rebased on the latest viewer sources I was able to find. To avoid rewriting history for forks, this new rebased code is in 'main' branch. This branch is the new default/base branch. As such CI scripts need to be update too.