### PR TITLE
Finalize/cleanup JDK 21 support

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-rc-1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/shell.nix
+++ b/shell.nix
@@ -1,20 +1,4 @@
-with import <nixpkgs> { overlays = [
-  (self: super:
-    let
-      # TODO: remove when JDK21 support is merged in
-      jdk21Pkgs = import (builtins.fetchTarball {
-        name = "jdk21Pkgs";
-        url = "https://github.com/NixOS/nixpkgs/archive/9a00ebc79fbdc9bed1964af8756ebec95af8191c.tar.gz";
-        #        # Use nix-prefetch-url --unpack to generate:
-        sha256 = "0rz45pyg1mnviw6l9vv65w84jpqzx84z3r78k1v77ciymjd5fdg9";
-      }) {};
-    in
-    {
-      jdk21 = jdk21Pkgs.jdk21;
-   }
-  )
-];};
-
+with import <nixpkgs> {};
 (pkgs.buildFHSUserEnv {
   name = "uiautomatorviewer-env";
   targetPkgs = pkgs: (with pkgs;


### PR DESCRIPTION
Update build configurations now that both Gradle and NixOS support JDK 21 in their stable versions