### PR TITLE
OpenDialog.java | Remove getInitialSize as it breaks with high dpi scaling on windows

### DIFF
--- a/src/main/java/com/android/uiautomator/OpenDialog.java
+++ b/src/main/java/com/android/uiautomator/OpenDialog.java
@@ -133,14 +133,6 @@ public class OpenDialog extends Dialog {
         updateButtonState();
     }
 
-    /**
-     * Return the initial size of the dialog.
-     */
-    @Override
-    protected Point getInitialSize() {
-        return new Point(368, 233);
-    }
-
     @Override
     protected void configureShell(Shell newShell) {
         super.configureShell(newShell);


### PR DESCRIPTION
https://stackoverflow.com/a/63894737